### PR TITLE
Animate relative to initial transform position and rotation in the scene

### DIFF
--- a/Packages/jp.keijiro.klak.timeline.procedural-motion/Runtime/ProceduralMotionMixer.cs
+++ b/Packages/jp.keijiro.klak.timeline.procedural-motion/Runtime/ProceduralMotionMixer.cs
@@ -9,6 +9,9 @@ namespace Klak.Timeline
     [System.Serializable]
     public class ProceduralMotionMixer : PlayableBehaviour
     {
+        public Vector3 InitialPosition { private get; set; }
+        public Quaternion InitialRotation { private get; set; }
+
         #region PlayableBehaviour overrides
 
         public override void PrepareFrame(Playable playable, FrameData info)
@@ -18,8 +21,8 @@ namespace Klak.Timeline
             {
                 // Reset the target transform.
                 // It'll be modified in clip playables.
-                target.localPosition = Vector3.zero;
-                target.localRotation = Quaternion.identity;
+                target.localPosition = InitialPosition;
+                target.localRotation = InitialRotation;
             }
         }
 

--- a/Packages/jp.keijiro.klak.timeline.procedural-motion/Runtime/ProceduralMotionTrack.cs
+++ b/Packages/jp.keijiro.klak.timeline.procedural-motion/Runtime/ProceduralMotionTrack.cs
@@ -17,7 +17,19 @@ namespace Klak.Timeline
     {
         public override Playable CreateTrackMixer(PlayableGraph graph, GameObject go, int inputCount)
         {
-            return ScriptPlayable<ProceduralMotionMixer>.Create(graph, inputCount);
+            var transform = go.GetComponent<PlayableDirector>().GetGenericBinding(this) as Transform;
+
+            if (transform == null)
+                return Playable.Null;
+
+            var playable = ScriptPlayable<ProceduralMotionMixer>.Create(graph, inputCount);
+            var behaviour = playable.GetBehaviour();
+
+            // Remember object's initial position and rotation.
+            behaviour.InitialPosition = transform.position;
+            behaviour.InitialRotation = transform.rotation;
+
+            return playable;
         }
 
         public override void GatherProperties(PlayableDirector director, IPropertyCollector driver)

--- a/Packages/jp.keijiro.klak.timeline.procedural-motion/Runtime/ProceduralMotionTrack.cs
+++ b/Packages/jp.keijiro.klak.timeline.procedural-motion/Runtime/ProceduralMotionTrack.cs
@@ -15,6 +15,9 @@ namespace Klak.Timeline
     [TrackBindingType(typeof(Transform))]
     public class ProceduralMotionTrack : TrackAsset
     {
+        [SerializeField]
+        bool animateRelativeToInitialPosition = true;
+
         public override Playable CreateTrackMixer(PlayableGraph graph, GameObject go, int inputCount)
         {
             var transform = go.GetComponent<PlayableDirector>().GetGenericBinding(this) as Transform;
@@ -25,9 +28,17 @@ namespace Klak.Timeline
             var playable = ScriptPlayable<ProceduralMotionMixer>.Create(graph, inputCount);
             var behaviour = playable.GetBehaviour();
 
-            // Remember object's initial position and rotation.
-            behaviour.InitialPosition = transform.position;
-            behaviour.InitialRotation = transform.rotation;
+            if (animateRelativeToInitialPosition)
+            {
+                // Remember object's initial position and rotation.
+                behaviour.InitialPosition = transform.position;
+                behaviour.InitialRotation = transform.rotation;
+            }
+            else
+            {
+                behaviour.InitialPosition = Vector3.zero;
+                behaviour.InitialRotation = Quaternion.identity;
+            }
 
             return playable;
         }

--- a/Packages/jp.keijiro.klak.timeline.procedural-motion/Runtime/ProceduralMotionTrack.cs
+++ b/Packages/jp.keijiro.klak.timeline.procedural-motion/Runtime/ProceduralMotionTrack.cs
@@ -37,13 +37,12 @@ namespace Klak.Timeline
             var transform = director.GetGenericBinding(this) as Transform;
             if (transform == null) return;
 
-            var go = transform.gameObject;
-            driver.AddFromName<Transform>(go, "m_LocalPosition.x");
-            driver.AddFromName<Transform>(go, "m_LocalPosition.y");
-            driver.AddFromName<Transform>(go, "m_LocalPosition.z");
-            driver.AddFromName<Transform>(go, "m_LocalRotation.x");
-            driver.AddFromName<Transform>(go, "m_LocalRotation.y");
-            driver.AddFromName<Transform>(go, "m_LocalRotation.z");
+            driver.AddFromName(transform, "m_LocalPosition.x");
+            driver.AddFromName(transform, "m_LocalPosition.y");
+            driver.AddFromName(transform, "m_LocalPosition.z");
+            driver.AddFromName(transform, "m_LocalRotation.x");
+            driver.AddFromName(transform, "m_LocalRotation.y");
+            driver.AddFromName(transform, "m_LocalRotation.z");
         }
     }
 }


### PR DESCRIPTION
This pull request adds the ability to animate objects relative to their original position/rotation in the scene (as captured when the timeline starts playing). This is a much better default for real world use cases, where objects are often placed by hand at various positions in the scene. I have also added a toggle in the track inspector that can be used to restore the original behavior.

As a side note, I also optimized the usage of AddFromName in GatherProperties. If you check PropertyCollector.cs, you'll see this behaves essentially the same, but skips a bunch of unnecessary GetComponent calls and null checks. This might seem unnecessary, but surprisingly enough, property collection can get reaaaally slow if you have a very large timeline, and this makes the editor lag which impedes iteration speed.

I'm also pretty sure we could get it down to:
```csharp
driver.AddFromName(transform, "m_LocalPosition");
driver.AddFromName(transform, "m_LocalRotation");
```
but I'm not entirely sure if that's any better.